### PR TITLE
トレーリングストップBotの実装

### DIFF
--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -38,6 +38,11 @@ class Bot < ApplicationRecord
   end
   # このガード節DRYじゃないが、拡張性必要なのでこのままでいい
 
+  # 注文処理リトライオーバー時の後片付け処理
+  def giveup
+    post_giveup
+  end
+
   def inherited_bot?
     is_a?(Bot) && !instance_of?(Bot)
   end
@@ -55,6 +60,10 @@ class Bot < ApplicationRecord
   end
 
   def post_order(_job_id, _timestamp)
+    raise 'No Implementation'
+  end
+
+  def post_giveup
     raise 'No Implementation'
   end
 

--- a/app/models/dollcost_average_bot.rb
+++ b/app/models/dollcost_average_bot.rb
@@ -52,6 +52,10 @@ class DollcostAverageBot < Bot
     order_logs.create(job_id: job_id, message: msg, currency_pair_id: currency_pair.id)
   end
 
+  def post_giveup
+    # NOP
+  end
+
   private
 
   def requre_rounded_inerval

--- a/app/models/trailing_stop_bot.rb
+++ b/app/models/trailing_stop_bot.rb
@@ -18,9 +18,9 @@ class TrailingStopBot < Bot
 
     msg =
       if res['success']
-        "#{currency_pair.name}を#{ts_key_amount}#{currency_pair.key_currency}購入しました"
+        "#{currency_pair.name}を#{ts_key_amount}#{currency_pair.key_currency}売却しました"
       else
-        "#{currency_pair.name}を#{ts_key_amount}#{currency_pair.key_currency}購入しましたが、「#{res['error']}」となりました"
+        "#{currency_pair.name}を#{ts_key_amount}#{currency_pair.key_currency}売却しましたが、「#{res['error']}」となりました"
       end
 
     order_logs.create(job_id: job_id, message: msg, currency_pair_id: currency_pair.id)

--- a/app/models/trailing_stop_bot.rb
+++ b/app/models/trailing_stop_bot.rb
@@ -27,4 +27,9 @@ class TrailingStopBot < Bot
 
     complete!
   end
+
+  def post_giveup
+    # 1ジョブで成功しなければNonceが更新されるため多重注文防止を担保不可となるので閉塞する。
+    complete!
+  end
 end

--- a/app/models/trailing_stop_bot.rb
+++ b/app/models/trailing_stop_bot.rb
@@ -8,7 +8,23 @@ class TrailingStopBot < Bot
     Float(rate) <= thresh
   end
 
-  def post_order(_job_id, _timestamp)
+  def post_order(job_id, timestamp)
+    req = coincheck_client(timestamp).create_orders(
+      order_type: 'market_sell',
+      amount: ts_key_amount.to_s,
+      pair: currency_pair.name
+    )
+    res = JSON.parse(req.body)
+
+    msg =
+      if res['success']
+        "#{currency_pair.name}を#{ts_key_amount}#{currency_pair.key_currency}購入しました"
+      else
+        "#{currency_pair.name}を#{ts_key_amount}#{currency_pair.key_currency}購入しましたが、「#{res['error']}」となりました"
+      end
+
+    order_logs.create(job_id: job_id, message: msg, currency_pair_id: currency_pair.id)
+
     complete!
   end
 end

--- a/app/workers/order_worker.rb
+++ b/app/workers/order_worker.rb
@@ -1,6 +1,11 @@
 class OrderWorker < ApplicationWorker
   sidekiq_options retry: 2
 
+  sidekiq_retries_exhausted do |msg, _e|
+    b = Bot.find(msg['args'].first)
+    b.giveup
+  end
+
   def perform(bid, timestamp)
     b = Bot.find(bid)
 

--- a/spec/factories/bots.rb
+++ b/spec/factories/bots.rb
@@ -16,4 +16,10 @@ FactoryBot.define do
       dca_interval_value 1
     end
   end
+
+  factory :trailing_stop_bot do
+    level_base 4_000_000
+    level_slope 100
+    ts_key_amount 0.4
+  end
 end


### PR DESCRIPTION
Close #33 

注文ジョブはエラー時リトライするが、回数閾値(2)を超過した場合、Botは完了状態に遷移にする。
(次回定期更新処理での注文となり、更新されたNonceが使われ多重注文防止が担保不可のため)
